### PR TITLE
Add full load when cache has an error message

### DIFF
--- a/assets/js/src/DocPageLoader.js
+++ b/assets/js/src/DocPageLoader.js
@@ -301,8 +301,14 @@ export default class DocPageLoader extends Snowboard.Singleton {
         }
 
         event.preventDefault();
+        const cached = this.cached[element.dataset.docPage];
 
-        if (this.cached[element.dataset.docPage]) {
+        if (cached) {
+            if (cached.hasOwnProperty('error')){
+                const newUrl = element.getAttribute('href');
+                window.location.href = newUrl;
+                return;
+            }
             const hash = window.location.hash.replace('#', '');
             history.pushState({ path: element.dataset.docPage, hash }, '', element.getAttribute('href'));
             this.currentState = { path: element.dataset.docPage, hash };


### PR DESCRIPTION
<!--
Pull Requests without a descriptive title, thorough description, or tests will be closed.

Please include the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc. The more detail the better.

If documentation improvements are required, you are expected to make a simultaneous pull request to https://github.com/wintercms/docs to update the documentation
-->
## Releated Issue
Closes #4

## Updates
 When a page does not exist, the cached object returns: 
 ```
  {
  error: 'The page that you have requested does not exist',
  X_WINTER_SUCCESS: false,
  X_WINTER_RESPONSE_CODE: 406
}
```
This update checks for an error key in the object and triggers a full page load via `window.location.href`.

